### PR TITLE
Handle connection refused while waiting for port

### DIFF
--- a/virt_up/instance.py
+++ b/virt_up/instance.py
@@ -518,7 +518,9 @@ class Instance:
                 s.settimeout(2)
                 s.connect((address, int(port)))
                 return True
-            except:
+            except Exception as e:
+                if str(e) == "[Errno 111] Connection refused":
+                    time.sleep(2) 
                 pass
             finally:
                 try:


### PR DESCRIPTION
There is no pause after a connection refused condition.  This can lead to
consuming all the remaining retries.

Add a test for the connection refused status and sleep for 2 seconds
before retrying.