### PR TITLE
WIP Provide a method to override specific template fields

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -13,9 +13,10 @@ Common Settings
 ---------------
 
 The ``settings.cfg`` file contains settings that are used when creating any
-virtual machine. The file should contain one section called ``[common]``.
+virtual machine. The file should contain one section called ``[common]`` and
+an optional section ``[overrride]``.
 
-The following fields are supported:
+The following fields are supported in the ``[common]`` section:
 
 **pool**
   The libvirt storage pool to write images. (default: ``default``)
@@ -67,6 +68,21 @@ The following fields are supported:
 
 These fields can be overridden by individual template definitions.
 
+The ``[override]`` section provides a method to modify of any setting on a per template definition basis.
+The override is applied after reading the template definition.
+
+The format is:
+**``template name``.``field name``**
+  The argument will replace a specific template's value for the field.  A simple method of subsitition
+  is available by inserting ``{fieldname}`` into the argument.
+
+  Example:
+     [override]
+     generic/centos8.virt-builder-args = {virt-builder-args}
+            --edit "/etc/default/grub:s/GRUB_CMDLINE_LINUX=\"/GRUB_CMDLINE_LINUX=\"debug\ /"
+            --run-command 'grub2-mkconfig -o /boot/grub2/grub.cfg'
+     generic/centos8.
+
 Template definitions
 --------------------
 
@@ -116,5 +132,9 @@ option. The following fields are supported:
 **instance-playbook**
   Optional ansible playbook to be executed on newly created instances. (default: None)
 
-In addition, the template configuration can override fields set in the ``common``
-section of the settings.cfg file.
+Summary of configuration processing order
+-----------------------------------------
+The ``[common]`` section of the ``settings.cfg`` provide system wide defaults.
+
+The definitions found in the template.d sub-directory are used and can be
+overriden by the statements found in the ``[override]`` section of the ``settings.cfg`` file.

--- a/virt_up/instance.py
+++ b/virt_up/instance.py
@@ -122,6 +122,7 @@ class Settings:
         # Load common settings.
         settings = self._load('settings.cfg')
         common = settings.get('common', {})
+        override = settings.get('override', {})
 
         # Load template specific settings.
         templates = self._load('templates.d/*.cfg')
@@ -130,7 +131,14 @@ class Settings:
 
         template = templates[name]
         def get(option, default):
-            return template.get(option, common.get(option, default))
+            optval = template.get(option, common.get(option, default))
+            override_option = name + '.' + option
+            if override_option in override:
+                try:
+                    optval = override[override_option].format(**{option:optval})
+                except KeyError:
+                    pass
+            return optval
 
         self.template_name = name
         self.desc = get('desc', '')


### PR DESCRIPTION
Add support for a new section optional section to setting.cfg that
can override a specific template field.  These overrides are applied
after reading the template definition.

This eliminates the need to copy an entire template in order to
customize just one or two fields.